### PR TITLE
Add libmysqlclient-dev package for cluster & migration feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
  apt-get update && \
  apt-get install -y \
 	iptables \
+	libmysqlclient-dev \
 	net-tools \
 	rsync \
 	sqlite3 && \


### PR DESCRIPTION
As per the message says on the cluster admin page:

![image](https://user-images.githubusercontent.com/1321933/55511190-f70f4180-562d-11e9-90cb-fd66a0b41f75.png)

It is also mentioned [here](https://openvpn.net/vpn-server-resources/configuration-database-management-and-backups/#change-database-backend-to-mysql-or-amazon-rds):

> You will need at minimum mysql-client package installed on your system, and in some cases libmysqlclient-dev as well.

It looks like you may need the dev package to use the migration tool.