### PR TITLE
Persistent Customization Folders

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,6 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.06.20:", desc: "Added Support for persistent Customization Folders." }
   - { date: "26.03.20:", desc: "Switch to using the openvpn-as repo for packages." }
   - { date: "29.08.19:", desc: "Update Application Setup instructions in readme to fix 2.7.5 login issue for existing users." }
   - { date: "27.08.19:", desc: "Add new clients package to install and upgrade process." }

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -40,7 +40,7 @@ if [ -f /version.txt ]; then
 		echo "backing up as.conf"
 		cp /config/etc/as.conf /config/backup/as.conf
 		cd /config || exit
-		rm -rf !("backup"|"log")
+		rm -rf !("backup"|"log"|"custom-cont-init.d"|"custom-services.d")
 		apt-get update && \
 		apt-get install -y \
 			openvpn-as=$OPENVPNAS_VERSION


### PR DESCRIPTION
## Description:
Excluded custom-cont-init.d & custom-services.d Folders from getting removed so scripts inside there are persistent

## Benefits of this PR and context:
Users can add there custom Scripts as described in [https://blog.linuxserver.io/2019/09/14/customizing-our-containers/](https://blog.linuxserver.io/2019/09/14/customizing-our-containers/) again.

## How Has This Been Tested?
I'm not able to test it.